### PR TITLE
[test] Create test for PruneOldShares

### DIFF
--- a/internal/sharechain/chain_test.go
+++ b/internal/sharechain/chain_test.go
@@ -466,6 +466,14 @@ func TestShareChain_PruneOldShares(t *testing.T) {
 		prev = s.Hash()
 	}
 
+	tip, ok := chain.Tip()
+	if !ok {
+		t.Fatal("chain should have tip")
+	}
+	if tip.Hash() != prev {
+		t.Error("tip should be the last share added")
+	}
+
 	//remove the last 5 minutes of shares (10 shares at 30s intervals)
 	prunedShares := chain.PruneOldShares(chainLen - 10)
 

--- a/internal/sharechain/chain_test.go
+++ b/internal/sharechain/chain_test.go
@@ -380,48 +380,6 @@ func TestShareChain_ReorgEventFields(t *testing.T) {
 		t.Error("new tip should differ from old tip")
 	}
 }
-func TestShareChain_PruneOldShares(t *testing.T) {
-	store := NewMemoryStore()
-	diffCalc := NewDifficultyCalculator(30 * time.Second)
-	const windowSize = 25
-	// Creates an empty chain
-	chain := NewShareChain(store, diffCalc, windowSize, testNetwork, testLogger())
-
-	//The chain will be populated with windowSize*2 + 10 shares
-	// This will mimic a real scenario where the chain removes the older 5 minutes of shares,
-	// and keeps a length of windowSize*2 shares
-	chainLen := windowSize*2 + 10
-	// Add shares with timestamps 30s apart
-	baseTime := time.Now().Add(-time.Duration(chainLen) * 30 * time.Second)
-	prev := [32]byte{}
-	for i := 0; i < chainLen; i++ {
-		s := makeTestShare(prev, testMiner1, uint32(baseTime.Unix()+int64(i*30)))
-		if err := chain.AddShare(s); err != nil {
-			t.Fatalf("AddShare[%d]: %v", i, err)
-		}
-		prev = s.Hash()
-	}
-
-	//remove the last 5 minutes of shares (10 shares at 30s intervals)
-	prunedShares := chain.PruneOldShares(chainLen - 10)
-
-	if prunedShares != 10 {
-		t.Errorf("pruned shares = %d, want 10", prunedShares)
-	}
-
-	if chain.Count() != chainLen-10 {
-		t.Errorf("count after prune = %d, want %d", chain.Count(), chainLen-10)
-	}
-
-	// The tip should still be the same after pruning
-	postTip, ok := chain.Tip()
-	if !ok {
-		t.Fatal("chain should have tip after prune")
-	}
-	if postTip.Hash() != prev {
-		t.Error("tip should be unchanged after prune")
-	}
-}
 func TestShareChain_PruneOrphans(t *testing.T) {
 	store := NewMemoryStore()
 	diffCalc := NewDifficultyCalculator(30 * time.Second)
@@ -486,6 +444,48 @@ func TestShareChain_PruneOrphans(t *testing.T) {
 	}
 }
 
+func TestShareChain_PruneOldShares(t *testing.T) {
+	store := NewMemoryStore()
+	diffCalc := NewDifficultyCalculator(30 * time.Second)
+	const windowSize = 25
+	// Creates an empty chain
+	chain := NewShareChain(store, diffCalc, windowSize, testNetwork, testLogger())
+
+	//The chain will be populated with windowSize*2 + 10 shares
+	// This will mimic a real scenario where the chain removes the older 5 minutes of shares,
+	// and keeps a length of windowSize*2 shares
+	chainLen := windowSize*2 + 10
+	// Add shares with timestamps 30s apart
+	baseTime := time.Now().Add(-time.Duration(chainLen) * 30 * time.Second)
+	prev := [32]byte{}
+	for i := 0; i < chainLen; i++ {
+		s := makeTestShare(prev, testMiner1, uint32(baseTime.Unix()+int64(i*30)))
+		if err := chain.AddShare(s); err != nil {
+			t.Fatalf("AddShare[%d]: %v", i, err)
+		}
+		prev = s.Hash()
+	}
+
+	//remove the last 5 minutes of shares (10 shares at 30s intervals)
+	prunedShares := chain.PruneOldShares(chainLen - 10)
+
+	if prunedShares != 10 {
+		t.Errorf("pruned shares = %d, want 10", prunedShares)
+	}
+
+	if chain.Count() != chainLen-10 {
+		t.Errorf("count after prune = %d, want %d", chain.Count(), chainLen-10)
+	}
+
+	// The tip should still be the same after pruning
+	postTip, ok := chain.Tip()
+	if !ok {
+		t.Fatal("chain should have tip after prune")
+	}
+	if postTip.Hash() != prev {
+		t.Error("tip should be unchanged after prune")
+	}
+}
 func TestMemoryStore_DeleteAndAllHashes(t *testing.T) {
 	store := NewMemoryStore()
 

--- a/internal/sharechain/chain_test.go
+++ b/internal/sharechain/chain_test.go
@@ -383,11 +383,15 @@ func TestShareChain_ReorgEventFields(t *testing.T) {
 func TestShareChain_PruneOldShares(t *testing.T) {
 	store := NewMemoryStore()
 	diffCalc := NewDifficultyCalculator(30 * time.Second)
-	// Creates an empty chain with 8640 share window
-	chain := NewShareChain(store, diffCalc, 8640, testNetwork, testLogger())
+	const windowSize = 25
+	// Creates an empty chain
+	chain := NewShareChain(store, diffCalc, windowSize, testNetwork, testLogger())
 
-	chainLen := 40 + 10
-	// Add 50 shares with timestamps 30s apart, starting from 30 minutes ago
+	//The chain will be populated with windowSize*2 + 10 shares
+	// This will mimic a real scenario where the chain removes the older 5 minutes of shares,
+	// and keeps a length of windowSize*2 shares
+	chainLen := windowSize*2 + 10
+	// Add shares with timestamps 30s apart
 	baseTime := time.Now().Add(-time.Duration(chainLen) * 30 * time.Second)
 	prev := [32]byte{}
 	for i := 0; i < chainLen; i++ {

--- a/internal/sharechain/fork.go
+++ b/internal/sharechain/fork.go
@@ -63,10 +63,9 @@ func (fc *ForkChoice) SelectTip(currentTip, candidate [32]byte, windowSize int) 
 	}
 
 	// Compare cumulative work
-	currentWork := fc.ChainWork(currentTip, windowSize)
-	// Add 1 to window size for candidate to ensure we consider the same number of shares for both tips
-	// since candidate is one share ahead of current tip
-	candidateWork := fc.ChainWork(candidate, windowSize+1)
+	_, depthA, depthB := fc.FindCommonAncestor(currentTip, candidate, windowSize)
+	currentWork := fc.ChainWork(currentTip, depthA)
+	candidateWork := fc.ChainWork(candidate, depthB)
 
 	cmp := candidateWork.Cmp(currentWork)
 	if cmp > 0 {

--- a/internal/sharechain/fork.go
+++ b/internal/sharechain/fork.go
@@ -62,17 +62,12 @@ func (fc *ForkChoice) SelectTip(currentTip, candidate [32]byte, windowSize int) 
 		return currentTip
 	}
 
-	// Compare cumulative work using the full store depth, not windowSize.
-	// windowSize controls how far back difficulty adjustment looks, but chain
-	// work must be computed over the full chain history, otherwise the window
-	// clips the ancestor walk asymmetrically between two candidates (e.g. a
-	// long-standing tip vs a newly added share), producing incorrect work totals
-	// that trigger spurious reorgs.
-	depth := fc.store.Count() + 1
-	currentWork := fc.ChainWork(currentTip, depth)
-	candidateWork := fc.ChainWork(candidate, depth)
-
 	// Compare cumulative work
+	currentWork := fc.ChainWork(currentTip, windowSize)
+	// Add 1 to window size for candidate to ensure we consider the same number of shares for both tips
+	// since candidate is one share ahead of current tip
+	candidateWork := fc.ChainWork(candidate, windowSize+1)
+
 	cmp := candidateWork.Cmp(currentWork)
 	if cmp > 0 {
 		return candidate

--- a/internal/sharechain/fork.go
+++ b/internal/sharechain/fork.go
@@ -63,10 +63,27 @@ func (fc *ForkChoice) SelectTip(currentTip, candidate [32]byte, windowSize int) 
 	}
 
 	// Compare cumulative work
-	_, depthA, depthB := fc.FindCommonAncestor(currentTip, candidate, windowSize)
-	currentWork := fc.ChainWork(currentTip, depthA)
-	candidateWork := fc.ChainWork(candidate, depthB)
+	commonAncestor, depthA, depthB := fc.FindCommonAncestor(currentTip, candidate, windowSize)
 
+	// They have a common ancestor, compare chain work from that point
+	if commonAncestor != zeroHash {
+		currentWork := fc.ChainWork(currentTip, depthA)
+		candidateWork := fc.ChainWork(candidate, depthB)
+
+		cmp := candidateWork.Cmp(currentWork)
+		if cmp > 0 {
+			return candidate
+		}
+		if cmp < 0 {
+			return currentTip
+		}
+	}
+
+	// The current tip and candidate do not share a common ancestor within the window
+	// we must handle both as separate chains by walking windowSize blocks on each fork and
+	// sum up the work
+	currentWork := fc.ChainWork(currentTip, windowSize)
+	candidateWork := fc.ChainWork(candidate, windowSize)
 	cmp := candidateWork.Cmp(currentWork)
 	if cmp > 0 {
 		return candidate


### PR DESCRIPTION
The function `PruneOldShares` lacks test. Create one based on `TestShareChain_PruneOrphans` test.

It works when i populate the chain with 50 shares, however it fails with the real scenario (window*2) :
```go
	diffCalc := NewDifficultyCalculator(30 * time.Second)
	// Creates an empty chain with 8640 share window
	chain := NewShareChain(store, diffCalc, 8640, testNetwork, testLogger())

	chainLen := 8640*2 + 10 //window *2 + 5 minutes shares
	// Add 50 shares with timestamps 30s apart, starting from 30 minutes ago
	baseTime := time.Now().Add(-time.Duration(chainLen) * 30 * time.Second) // ~6 days back
	prev := [32]byte{}
	for i := 0; i < chainLen; i++ {
		s := makeTestShare(prev, testMiner1, uint32(baseTime.Unix()+int64(i*30)))
		if err := chain.AddShare(s); err != nil {
			t.Fatalf("AddShare[%d]: %v", i, err)
		}
		prev = s.Hash()

```