### PR TITLE
Optimize prune old

### DIFF
--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -247,7 +247,7 @@ func (n *Node) eventLoop(ctx context.Context) {
 			if pruned := n.chain.PruneOrphans(); pruned > 0 {
 				n.logger.Info("pruned orphan shares", zap.Int("count", pruned))
 			}
-			n.chain.PruneOldShares(n.config.PPLNSWindowSize * 2)
+			n.chain.PruneToDepth(n.config.PPLNSWindowSize * 2)
 		}
 	}
 }
@@ -1267,7 +1267,6 @@ func (n *Node) submitBlock(header []byte, coinbase []byte, tmpl *bitcoin.BlockTe
 		}
 	}
 }
-
 
 // applyVersionRolling computes the actual block version by merging the miner's
 // rolled version bits into the original job version using the BIP 310 mask.

--- a/internal/sharechain/boltstore.go
+++ b/internal/sharechain/boltstore.go
@@ -251,7 +251,7 @@ func (s *BoltStore) HashesNotIn(keep map[[32]byte]struct{}) [][32]byte {
 	defer s.mu.RUnlock()
 
 	// Collect hashes that are in the store but not in the keep set
-	toDelete := make([][32]byte, len(s.shares)-len(keep))
+	toDelete := make([][32]byte, 0, len(s.shares)-len(keep))
 	// Iterate over the whole store and check if the hash is in the keep set.
 	// If not, add it to the list of hashes to delete.
 	//  TODO: This can be obtimized by creating an inex of the store

--- a/internal/sharechain/chain.go
+++ b/internal/sharechain/chain.go
@@ -329,9 +329,9 @@ func (sc *ShareChain) PruneOrphans() int {
 	return pruned
 }
 
-// PruneOldShares removes shares beyond the most recent maxKeep on the main chain.
+// PruneToDepth removes shares beyond the most recent maxKeep on the main chain.
 // Returns the number of shares pruned.
-func (sc *ShareChain) PruneOldShares(maxKeep int) int {
+func (sc *ShareChain) PruneToDepth(maxKeep int) int {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
 
@@ -348,13 +348,7 @@ func (sc *ShareChain) PruneOldShares(maxKeep int) int {
 		keepSet[s.Hash()] = struct{}{}
 	}
 
-	allHashes := sc.store.AllHashes()
-	var toDelete [][32]byte
-	for _, h := range allHashes {
-		if _, keep := keepSet[h]; !keep {
-			toDelete = append(toDelete, h)
-		}
-	}
+	toDelete := sc.store.HashesNotIn(keepSet)
 
 	if len(toDelete) == 0 {
 		return 0

--- a/internal/sharechain/chain_test.go
+++ b/internal/sharechain/chain_test.go
@@ -466,6 +466,14 @@ func TestShareChain_PruneOldShares(t *testing.T) {
 		prev = s.Hash()
 	}
 
+	tip, ok := chain.Tip()
+	if !ok {
+		t.Fatal("chain should have tip")
+	}
+	if tip.Hash() != prev {
+		t.Error("tip should be the last share added")
+	}
+
 	//remove the last 5 minutes of shares (10 shares at 30s intervals)
 	prunedShares := chain.PruneOldShares(chainLen - 10)
 

--- a/internal/sharechain/chain_test.go
+++ b/internal/sharechain/chain_test.go
@@ -380,48 +380,6 @@ func TestShareChain_ReorgEventFields(t *testing.T) {
 		t.Error("new tip should differ from old tip")
 	}
 }
-func TestShareChain_PruneOldShares(t *testing.T) {
-	store := NewMemoryStore()
-	diffCalc := NewDifficultyCalculator(30 * time.Second)
-	const windowSize = 25
-	// Creates an empty chain
-	chain := NewShareChain(store, diffCalc, windowSize, testNetwork, testLogger())
-
-	//The chain will be populated with windowSize*2 + 10 shares
-	// This will mimic a real scenario where the chain removes the older 5 minutes of shares,
-	// and keeps a length of windowSize*2 shares
-	chainLen := windowSize*2 + 10
-	// Add shares with timestamps 30s apart
-	baseTime := time.Now().Add(-time.Duration(chainLen) * 30 * time.Second)
-	prev := [32]byte{}
-	for i := 0; i < chainLen; i++ {
-		s := makeTestShare(prev, testMiner1, uint32(baseTime.Unix()+int64(i*30)))
-		if err := chain.AddShare(s); err != nil {
-			t.Fatalf("AddShare[%d]: %v", i, err)
-		}
-		prev = s.Hash()
-	}
-
-	//remove the last 5 minutes of shares (10 shares at 30s intervals)
-	prunedShares := chain.PruneOldShares(chainLen - 10)
-
-	if prunedShares != 10 {
-		t.Errorf("pruned shares = %d, want 10", prunedShares)
-	}
-
-	if chain.Count() != chainLen-10 {
-		t.Errorf("count after prune = %d, want %d", chain.Count(), chainLen-10)
-	}
-
-	// The tip should still be the same after pruning
-	postTip, ok := chain.Tip()
-	if !ok {
-		t.Fatal("chain should have tip after prune")
-	}
-	if postTip.Hash() != prev {
-		t.Error("tip should be unchanged after prune")
-	}
-}
 func TestShareChain_PruneOrphans(t *testing.T) {
 	store := NewMemoryStore()
 	diffCalc := NewDifficultyCalculator(30 * time.Second)
@@ -486,6 +444,48 @@ func TestShareChain_PruneOrphans(t *testing.T) {
 	}
 }
 
+func TestShareChain_PruneOldShares(t *testing.T) {
+	store := NewMemoryStore()
+	diffCalc := NewDifficultyCalculator(30 * time.Second)
+	const windowSize = 25
+	// Creates an empty chain
+	chain := NewShareChain(store, diffCalc, windowSize, testNetwork, testLogger())
+
+	//The chain will be populated with windowSize*2 + 10 shares
+	// This will mimic a real scenario where the chain removes the older 5 minutes of shares,
+	// and keeps a length of windowSize*2 shares
+	chainLen := windowSize*2 + 10
+	// Add shares with timestamps 30s apart
+	baseTime := time.Now().Add(-time.Duration(chainLen) * 30 * time.Second)
+	prev := [32]byte{}
+	for i := 0; i < chainLen; i++ {
+		s := makeTestShare(prev, testMiner1, uint32(baseTime.Unix()+int64(i*30)))
+		if err := chain.AddShare(s); err != nil {
+			t.Fatalf("AddShare[%d]: %v", i, err)
+		}
+		prev = s.Hash()
+	}
+
+	//remove the last 5 minutes of shares (10 shares at 30s intervals)
+	prunedShares := chain.PruneOldShares(chainLen - 10)
+
+	if prunedShares != 10 {
+		t.Errorf("pruned shares = %d, want 10", prunedShares)
+	}
+
+	if chain.Count() != chainLen-10 {
+		t.Errorf("count after prune = %d, want %d", chain.Count(), chainLen-10)
+	}
+
+	// The tip should still be the same after pruning
+	postTip, ok := chain.Tip()
+	if !ok {
+		t.Fatal("chain should have tip after prune")
+	}
+	if postTip.Hash() != prev {
+		t.Error("tip should be unchanged after prune")
+	}
+}
 func TestMemoryStore_DeleteAndAllHashes(t *testing.T) {
 	store := NewMemoryStore()
 

--- a/internal/sharechain/chain_test.go
+++ b/internal/sharechain/chain_test.go
@@ -475,7 +475,7 @@ func TestShareChain_PruneOldShares(t *testing.T) {
 	}
 
 	//remove the last 5 minutes of shares (10 shares at 30s intervals)
-	prunedShares := chain.PruneOldShares(chainLen - 10)
+	prunedShares := chain.PruneToDepth(chainLen - 10)
 
 	if prunedShares != 10 {
 		t.Errorf("pruned shares = %d, want 10", prunedShares)

--- a/internal/sharechain/chain_test.go
+++ b/internal/sharechain/chain_test.go
@@ -383,11 +383,15 @@ func TestShareChain_ReorgEventFields(t *testing.T) {
 func TestShareChain_PruneOldShares(t *testing.T) {
 	store := NewMemoryStore()
 	diffCalc := NewDifficultyCalculator(30 * time.Second)
-	// Creates an empty chain with 8640 share window
-	chain := NewShareChain(store, diffCalc, 8640, testNetwork, testLogger())
+	const windowSize = 25
+	// Creates an empty chain
+	chain := NewShareChain(store, diffCalc, windowSize, testNetwork, testLogger())
 
-	chainLen := 40 + 10
-	// Add 50 shares with timestamps 30s apart, starting from 30 minutes ago
+	//The chain will be populated with windowSize*2 + 10 shares
+	// This will mimic a real scenario where the chain removes the older 5 minutes of shares,
+	// and keeps a length of windowSize*2 shares
+	chainLen := windowSize*2 + 10
+	// Add shares with timestamps 30s apart
 	baseTime := time.Now().Add(-time.Duration(chainLen) * 30 * time.Second)
 	prev := [32]byte{}
 	for i := 0; i < chainLen; i++ {

--- a/internal/sharechain/fork.go
+++ b/internal/sharechain/fork.go
@@ -63,10 +63,9 @@ func (fc *ForkChoice) SelectTip(currentTip, candidate [32]byte, windowSize int) 
 	}
 
 	// Compare cumulative work
-	currentWork := fc.ChainWork(currentTip, windowSize)
-	// Add 1 to window size for candidate to ensure we consider the same number of shares for both tips
-	// since candidate is one share ahead of current tip
-	candidateWork := fc.ChainWork(candidate, windowSize+1)
+	_, depthA, depthB := fc.FindCommonAncestor(currentTip, candidate, windowSize)
+	currentWork := fc.ChainWork(currentTip, depthA)
+	candidateWork := fc.ChainWork(candidate, depthB)
 
 	cmp := candidateWork.Cmp(currentWork)
 	if cmp > 0 {

--- a/internal/sharechain/fork.go
+++ b/internal/sharechain/fork.go
@@ -62,17 +62,12 @@ func (fc *ForkChoice) SelectTip(currentTip, candidate [32]byte, windowSize int) 
 		return currentTip
 	}
 
-	// Compare cumulative work using the full store depth, not windowSize.
-	// windowSize controls how far back difficulty adjustment looks, but chain
-	// work must be computed over the full chain history, otherwise the window
-	// clips the ancestor walk asymmetrically between two candidates (e.g. a
-	// long-standing tip vs a newly added share), producing incorrect work totals
-	// that trigger spurious reorgs.
-	depth := fc.store.Count() + 1
-	currentWork := fc.ChainWork(currentTip, depth)
-	candidateWork := fc.ChainWork(candidate, depth)
-
 	// Compare cumulative work
+	currentWork := fc.ChainWork(currentTip, windowSize)
+	// Add 1 to window size for candidate to ensure we consider the same number of shares for both tips
+	// since candidate is one share ahead of current tip
+	candidateWork := fc.ChainWork(candidate, windowSize+1)
+
 	cmp := candidateWork.Cmp(currentWork)
 	if cmp > 0 {
 		return candidate

--- a/internal/sharechain/store.go
+++ b/internal/sharechain/store.go
@@ -21,6 +21,8 @@ type ShareStore interface {
 	Delete(hash [32]byte) error
 	// AllHashes returns the hashes of all shares in the store.
 	AllHashes() [][32]byte
+	// HashesNotIn returns all hashes in the store that are not in the given keep set.
+	HashesNotIn(keep map[[32]byte]struct{}) [][32]byte
 	Close() error
 }
 
@@ -114,6 +116,22 @@ func (s *MemoryStore) AllHashes() [][32]byte {
 		hashes = append(hashes, h)
 	}
 	return hashes
+}
+
+func (s *MemoryStore) HashesNotIn(keep map[[32]byte]struct{}) [][32]byte {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	// Collect hashes that are in the store but not in the keep set
+	toDelete := make([][32]byte, len(s.shares)-len(keep))
+	// Iterate over the whole store and check if the hash is in the keep set.
+	// If not, add it to the list of hashes to delete.
+	for h := range s.shares {
+		if _, ok := keep[h]; !ok {
+			toDelete = append(toDelete, h)
+		}
+	}
+	return toDelete
 }
 
 func (s *MemoryStore) Close() error { return nil }

--- a/internal/sharechain/store.go
+++ b/internal/sharechain/store.go
@@ -123,7 +123,7 @@ func (s *MemoryStore) HashesNotIn(keep map[[32]byte]struct{}) [][32]byte {
 	defer s.mu.RUnlock()
 
 	// Collect hashes that are in the store but not in the keep set
-	toDelete := make([][32]byte, len(s.shares)-len(keep))
+	toDelete := make([][32]byte, 0, len(s.shares)-len(keep))
 	// Iterate over the whole store and check if the hash is in the keep set.
 	// If not, add it to the list of hashes to delete.
 	for h := range s.shares {


### PR DESCRIPTION
This PR depends on #3.

It introduces the following changes:

- **Rename `PruneOldShares` to `PruneToDepth`:** 
The parameter represents a depth, not a time, so this name is more accurate and descriptive.
- **Optimise the memory usage of `PruneOldShares`:**
The original function stored the same data twice: first, it retrieved all required shares (the ones to keep), and then it retrieved all the hashes in the shares. This caused a memory cost of O(2n).

This PR eliminates the duplication by introducing the `HashesNotIn(keep map[[32]byte]struct{}) [][32]byte` function, which directly returns the hashes to delete while following the same original logic.

Inside `PruneOldShares` the variable `allHashes := sc.store.AllHashes()` allocates  in mainnet 17,280 × 32 bytes = 552,960 bytes ≈ 540 KB.
With this change, we save approximately 540 KB of memory every 5 minutes.

**- Future improvement**
Ideally, this algorithm should be further optimised from O(n) to O(1) by using a proper indexation, avoiding iterating through the entire chain, and directly accessing the required elements, but for the moment i think this should be enough